### PR TITLE
YlideTokenAttachment

### DIFF
--- a/contracts/YlidePayV1.sol
+++ b/contracts/YlidePayV1.sol
@@ -46,10 +46,6 @@ contract YlidePayV1 is IYlideTokenAttachment, Owned, Pausable {
 		ylideMailer = _ylideMailer;
 	}
 
-	function contractType() public pure returns (ContractType) {
-		return ContractType.Pay;
-	}
-
 	function setYlideMailer(IYlideMailer _ylideMailer) external onlyOwner {
 		ylideMailer = _ylideMailer;
 	}

--- a/contracts/interfaces/IYlideTokenAttachment.sol
+++ b/contracts/interfaces/IYlideTokenAttachment.sol
@@ -4,14 +4,6 @@ pragma solidity ^0.8.17;
 import {IYlideMailer} from "./IYlideMailer.sol";
 
 interface IYlideTokenAttachment {
-	enum ContractType {
-		Pay,
-		Stake,
-		StreamSablier
-	}
-
-	function contractType() external pure returns (ContractType);
-
 	function setYlideMailer(IYlideMailer) external;
 
 	function pause() external;


### PR DESCRIPTION
Remove unnecessary ContractType for token attachment contracts. Handle all types of supplements using CONTRACT_TYPE constants https://github.com/ylide-io/ethereum-contracts/blob/bf6a831bb4ed496ce77ae43ed3160e499c4a5944/contracts/helpers/Constants.sol#L5