### PR TITLE
refactor safe and recipients

### DIFF
--- a/contracts/YlideMailerV9.sol
+++ b/contracts/YlideMailerV9.sol
@@ -58,12 +58,6 @@ contract YlideMailerV9 is
 		Supplement supplement
 	);
 
-	event ContentRecipients(
-		uint256 indexed contentId,
-		address indexed sender,
-		uint256[] recipients
-	);
-
 	event BroadcastPush(
 		address indexed sender,
 		uint256 indexed feedId,
@@ -386,7 +380,6 @@ contract YlideMailerV9 is
 				supplement
 			);
 		}
-		emit ContentRecipients(contentId, sender, args.recipients);
 
 		payOut(1, args.recipients.length, 0);
 		payOutMailingFeed(args.feedId, args.recipients.length);
@@ -454,7 +447,6 @@ contract YlideMailerV9 is
 				supplement
 			);
 		}
-		emit ContentRecipients(contentId, sender, args.recipients);
 
 		payOut(0, args.recipients.length, 0);
 		payOutMailingFeed(args.feedId, args.recipients.length);

--- a/contracts/YlideSafe1.sol
+++ b/contracts/YlideSafe1.sol
@@ -6,7 +6,6 @@ import {Owned} from "./helpers/Owned.sol";
 import {CONTRACT_TYPE_SAFE} from "./helpers/Constants.sol";
 
 import {IYlideMailer} from "./interfaces/IYlideMailer.sol";
-import {ISafe} from "./interfaces/ISafe.sol";
 
 contract YlideSafeV1 is Owned, Pausable {
 	uint256 public constant version = 1;
@@ -14,17 +13,19 @@ contract YlideSafeV1 is Owned, Pausable {
 	IYlideMailer public ylideMailer;
 
 	struct SafeArgs {
-		ISafe safeSender;
-		ISafe[] safeRecipients;
+		address safeSender;
+		address[] safeRecipients;
 	}
 
 	error InvalidSender();
-	error NotSafeSender();
-	error NotSafeRecipient(uint256 recipient, ISafe safe);
 	error InvalidArguments();
 
 	event YlideMailerChanged(address indexed ylideMailer);
-	event SafeMails(uint256 indexed contentId, ISafe indexed safeSender, ISafe[] safeRecipients);
+	event SafeMails(
+		uint256 indexed contentId,
+		address indexed safeSender,
+		address[] safeRecipients
+	);
 
 	constructor(IYlideMailer _ylideMailer) Owned() Pausable() {
 		ylideMailer = _ylideMailer;
@@ -78,19 +79,6 @@ contract YlideSafeV1 is Owned, Pausable {
 	) internal view {
 		if (sender != msg.sender) revert InvalidSender();
 		if (recipients.length != safeArgs.safeRecipients.length) revert InvalidArguments();
-		if (
-			address(safeArgs.safeSender) != address(0) &&
-			safeArgs.safeSender.isOwner(msg.sender) == false
-		) revert NotSafeSender();
-		for (uint256 i; i < recipients.length; ) {
-			if (
-				address(safeArgs.safeRecipients[i]) != address(0) &&
-				safeArgs.safeRecipients[i].isOwner(address(uint160(recipients[i]))) == false
-			) revert NotSafeRecipient(recipients[i], safeArgs.safeRecipients[i]);
-			unchecked {
-				i++;
-			}
-		}
 	}
 
 	function pause() external onlyOwner {

--- a/test/safe-v1.ts
+++ b/test/safe-v1.ts
@@ -92,18 +92,6 @@ describe('Ylide Safe', () => {
 			'0xf677181dfe0e10c6ea91d012f09c7f6da7477ec75489a2322fbbfe9d878224b2314121c86229a7a77a2a0a5f3b72fe4668ea8183938154374a8cde9aeff1a6d41b';
 
 		await expect(
-			ylideSafe.connect(user2).sendBulkMail(
-				getSendBulMailArgs([BigNumber.from(user1.address)]),
-				{
-					signature,
-					sender: user1.address,
-					nonce: 0,
-					deadline: 123,
-				},
-				{ safeSender: mockSafe.address, safeRecipients: [mockSafe2.address] },
-			),
-		).to.be.revertedWithCustomError(ylideSafe, 'InvalidSender');
-		await expect(
 			ylideSafe.connect(user2).addMailRecipients(
 				getAddMailRecipientsArgs([BigNumber.from(user1.address)]),
 				{
@@ -140,65 +128,10 @@ describe('Ylide Safe', () => {
 				{ safeSender: mockSafe.address, safeRecipients: [mockSafe2.address] },
 			),
 		).to.be.revertedWithCustomError(ylideSafe, 'InvalidArguments');
-
-		await expect(
-			ylideSafe.connect(user2).sendBulkMail(
-				getSendBulMailArgs([BigNumber.from(user1.address)]),
-				{
-					signature,
-					sender: user2.address,
-					nonce: 0,
-					deadline: 123,
-				},
-				{ safeSender: mockSafe.address, safeRecipients: [mockSafe2.address] },
-			),
-		).to.be.revertedWithCustomError(ylideSafe, 'NotSafeSender');
-		await expect(
-			ylideSafe.connect(user2).addMailRecipients(
-				getAddMailRecipientsArgs([BigNumber.from(user1.address)]),
-				{
-					signature,
-					sender: user2.address,
-					nonce: 0,
-					deadline: 123,
-				},
-				{ safeSender: mockSafe.address, safeRecipients: [mockSafe2.address] },
-			),
-		).to.be.revertedWithCustomError(ylideSafe, 'NotSafeSender');
-
-		await mockSafe.connect(owner).setOwners([user2.address], [true]);
-
-		await expect(
-			ylideSafe.connect(user2).sendBulkMail(
-				getSendBulMailArgs([BigNumber.from(user1.address)]),
-				{
-					signature,
-					sender: user2.address,
-					nonce: 0,
-					deadline: 123,
-				},
-				{ safeSender: mockSafe.address, safeRecipients: [mockSafe2.address] },
-			),
-		).to.be.revertedWithCustomError(ylideSafe, 'NotSafeRecipient');
-		await expect(
-			ylideSafe.connect(user2).addMailRecipients(
-				getAddMailRecipientsArgs([BigNumber.from(user1.address)]),
-				{
-					signature,
-					sender: user2.address,
-					nonce: 0,
-					deadline: 123,
-				},
-				{ safeSender: mockSafe.address, safeRecipients: [mockSafe2.address] },
-			),
-		).to.be.revertedWithCustomError(ylideSafe, 'NotSafeRecipient');
 	});
 
 	it('Owner of safe can send message using sendBulkMail', async () => {
 		await backToSnapshot(snapshot);
-
-		await mockSafe.setOwners([user1.address], [true]);
-		await mockSafe2.setOwners([user2.address], [true]);
 
 		const deadline = await currentTimestamp().then(t => t + 1000);
 		const nonce = await ylideMailer.nonces(user1.address);
@@ -215,8 +148,6 @@ describe('Ylide Safe', () => {
 			contractAddress: ylideSafe.address,
 			contractType: ContractType.SAFE,
 		});
-
-		expect(await mockSafe.isOwner(user1.address)).to.be.true;
 
 		await ylideSafe.connect(user1).sendBulkMail(
 			getSendBulMailArgs(recipients),
@@ -247,10 +178,6 @@ describe('Ylide Safe', () => {
 	it('Owner of safe can send message using addMailRecipients', async () => {
 		await backToSnapshot(snapshot);
 
-		await mockSafe.setOwners([user1.address], [true]);
-		await mockSafe2.setOwners([user2.address], [true]);
-		await mockSafe3.setOwners([user3.address], [true]);
-
 		const deadline = await currentTimestamp().then(t => t + 1000);
 		const nonce = await ylideMailer.nonces(user1.address);
 		const recipients = [BigNumber.from(user2.address), BigNumber.from(user3.address)];
@@ -268,8 +195,6 @@ describe('Ylide Safe', () => {
 			contractAddress: ylideSafe.address,
 			contractType: ContractType.SAFE,
 		});
-
-		expect(await mockSafe.isOwner(user1.address)).to.be.true;
 
 		await ylideSafe.connect(user1).addMailRecipients(
 			getAddMailRecipientsArgs(recipients),
@@ -300,8 +225,6 @@ describe('Ylide Safe', () => {
 	it('Not owner of any safe can send message to some user with Safe', async () => {
 		await backToSnapshot(snapshot);
 
-		await mockSafe2.setOwners([user2.address], [true]);
-
 		const deadline = await currentTimestamp().then(t => t + 1000);
 		const nonce = await ylideMailer.nonces(user1.address);
 		const recipients = [BigNumber.from(user2.address), BigNumber.from(user3.address)];
@@ -319,8 +242,6 @@ describe('Ylide Safe', () => {
 			contractAddress: ylideSafe.address,
 			contractType: ContractType.SAFE,
 		});
-
-		expect(await mockSafe.isOwner(user1.address)).to.be.false;
 
 		await ylideSafe.connect(user1).addMailRecipients(
 			getAddMailRecipientsArgs(recipients),


### PR DESCRIPTION
- Remove check for safe ownership to enable cross-chain messaging. 
- Remove ContentRecipients event, encode them directly in MessageContent event instead.